### PR TITLE
Introduce and new debug option with better logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /docs/
 
 .DS_Store
+
+Dockerfile

--- a/README.md
+++ b/README.md
@@ -12,12 +12,6 @@ npm install @anyone-protocol/anyone-client
 npx anyone-client
 ```
 
-## Run Anon Proxy (Example Usage)
-
-```sh
-npx anyone-proxy curl icanhazip.com
-```
-
 ## Build
 
 ```sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
         "unzipper": "^0.12.1"
       },
       "bin": {
-        "anyone-client": "out/anon-cli.js",
-        "anyone-proxy": "out/anon-proxy-cli.js"
+        "anyone-client": "out/anon-cli.js"
       },
       "devDependencies": {
         "@types/node": "^20.16.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "axios": "^1.7.2",
+        "chalk": "^4.1.2",
         "unzipper": "^0.12.1"
       },
       "bin": {
@@ -49,6 +50,20 @@
       "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
       "dev": true
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -84,6 +99,37 @@
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -166,6 +212,14 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -298,6 +352,17 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/typedoc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anyone-protocol/anyone-client",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anyone-protocol/anyone-client",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "",
   "main": "out/index.js",
   "bin": {
-    "anyone-client": "./out/anon-cli.js",
-    "anyone-proxy": "./out/anon-proxy-cli.js"
+    "anyone-client": "./out/anon-cli.js"
   },
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anyone-protocol/anyone-client",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "",
   "main": "out/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "axios": "^1.7.2",
+    "chalk": "^4.1.2",
     "unzipper": "^0.12.1"
   }
 }

--- a/src/anon-cli.ts
+++ b/src/anon-cli.ts
@@ -17,9 +17,9 @@ const args = parseArgs({
       type: 'string',
       short: 'c',
     },
-    debug: {
+    verbose: {
       type: 'boolean',
-      short: 'd',
+      short: 'v',
     }
   }
 });
@@ -48,9 +48,9 @@ if (args.values.controlPort !== undefined) {
   }
 }
 
-const debug = args.values.debug === true;
+const verbose = args.values.verbose === true;
 
-const anon = new Anon({ displayLog: debug, socksPort: socksPort, orPort: orPort, controlPort: controlPort });
+const anon = new Anon({ displayLog: verbose, socksPort: socksPort, orPort: orPort, controlPort: controlPort });
 
 (async () => {
   await anon.start();

--- a/src/anon-cli.ts
+++ b/src/anon-cli.ts
@@ -16,6 +16,10 @@ const args = parseArgs({
     controlPort: {
       type: 'string',
       short: 'c',
+    },
+    debug: {
+      type: 'boolean',
+      short: 'd',
     }
   }
 });
@@ -44,7 +48,9 @@ if (args.values.controlPort !== undefined) {
   }
 }
 
-const anon = new Anon({ displayLog: true, socksPort: socksPort, orPort: orPort, controlPort: controlPort });
+const debug = args.values.debug === true;
+
+const anon = new Anon({ displayLog: debug, socksPort: socksPort, orPort: orPort, controlPort: controlPort });
 
 (async () => {
   await anon.start();

--- a/src/anon-proxy-cli.ts
+++ b/src/anon-proxy-cli.ts
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+/**
+ * THIS FEATURE IS EXPERIMENTAL AND IN BETA, USE AT YOUR OWN RISK
+ */
+
 import { AnonProxy } from './anon-proxy';
 
 function parseArgs(): { socksPort?: number, args: string[] } {

--- a/src/anon-proxy.ts
+++ b/src/anon-proxy.ts
@@ -1,3 +1,7 @@
+/**
+ * THIS FEATURE IS EXPERIMENTAL AND IN BETA, USE AT YOUR OWN RISK
+ */
+
 import { ChildProcess, spawn } from 'child_process';
 import { AnonProxyConfig, createAnonProxyConfigFile } from './config/config';
 import { getBinaryPath } from './utils';

--- a/src/anon.ts
+++ b/src/anon.ts
@@ -1,6 +1,7 @@
 import { ChildProcess, spawn, execFile } from 'child_process';
 import { AnonConfig, createAnonConfigFile } from './config/config';
 import { getBinaryPath } from './utils';
+import chalk from 'chalk';
 
 /**
  * Allows to run Anon client with different configuration options
@@ -75,8 +76,22 @@ export class Anon {
     const child = spawn(binaryPath, args, { detached: false });
 
     child.stdout.on('data', (data) => {
-      if (this.options?.displayLog === true) {
-        console.log(`${data}`);
+      const logLines = data.toString().split('\n');
+    
+      for (const line of logLines) {
+        if (this.options?.displayLog === true) {
+          console.log(line);
+        } else {
+          const bootstrapMatch = line.match(/Bootstrapped (\d+)%.*?: (.+)/);
+          if (bootstrapMatch) {
+            const [, percentage, status] = bootstrapMatch;
+            const formattedPercentage = chalk.green(`${percentage}%`);
+            const formattedStatus = chalk.blue(status);
+            console.log(`Bootstrapped ${formattedPercentage}: ${formattedStatus}`);
+          } else if (line.match(/\[err\]/i)) {
+            console.log(chalk.red(line));
+          }
+        }
       }
     });
 


### PR DESCRIPTION
This PR improves the visual aspect of the CLI to not bog down users with the client code. Minimal logs are shown to show users the package is running now.
The `-v` or `--verbose` argument can be used to output the client code for debugging.

## How
`chalk` package `v4` is used for rendering the coloured text. `v5` is not used as it cannot be used as CommonJS import. Errors and Bootstrapping messages are shown in coloured text to stdout as of now.