### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Publish @anyone-protocol/anyone-client to npm
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/anyone-protocol/anon-protocol-npm/security/code-scanning/1](https://github.com/anyone-protocol/anon-protocol-npm/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow, either at the root level (applies to all jobs) or at the job level (applies only to the specific job). Since there is only one job in this workflow, adding it at the root is simplest and most maintainable. The minimal required permission for this workflow is `contents: read`, which allows the workflow to check out code and read repository files, but not to write to the repository or perform other privileged actions. You should add the following block directly after the `name:` and before the `on:` block in `.github/workflows/npm-publish.yml`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
